### PR TITLE
add socket-io hook

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,9 +3,17 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+Object.defineProperty(exports, "useSocketIO", {
+  enumerable: true,
+  get: function get() {
+    return _useSocketIo.useSocketIO;
+  }
+});
 exports["default"] = void 0;
 
 var _useWebsocket = require("./lib/use-websocket");
+
+var _useSocketIo = require("./lib/use-socket-io");
 
 var _default = _useWebsocket.useWebSocket;
 exports["default"] = _default;

--- a/dist/lib/use-socket-io.js
+++ b/dist/lib/use-socket-io.js
@@ -1,0 +1,62 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.useSocketIO = void 0;
+
+var _react = require("react");
+
+var _useWebsocket = require("./use-websocket");
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+var emptyEvent = {
+  type: 'empty',
+  payload: null
+};
+
+var getSocketData = function getSocketData(event) {
+  if (!event || !event.data) {
+    return emptyEvent;
+  }
+
+  var match = event.data.match(/\[.*]/);
+
+  if (!match) {
+    return emptyEvent;
+  }
+
+  var data = JSON.parse(match);
+
+  if (!Array.isArray(data) || !data[1]) {
+    return emptyEvent;
+  }
+
+  return {
+    type: data[0],
+    payload: data[1]
+  };
+};
+
+var useSocketIO = function useSocketIO(url) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : DEFAULT_OPTIONS;
+
+  var _useWebSocket = (0, _useWebsocket.useWebSocket)(url, options),
+      _useWebSocket2 = _slicedToArray(_useWebSocket, 3),
+      sendMessage = _useWebSocket2[0],
+      lastMessage = _useWebSocket2[1],
+      readyStateFromUrl = _useWebSocket2[2];
+
+  return [sendMessage, (0, _react.useMemo)(function () {
+    return getSocketData(lastMessage);
+  }, [lastMessage]), readyStateFromUrl];
+};
+
+exports.useSocketIO = useSocketIO;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 import { useWebSocket } from './lib/use-websocket';
 
+export { useSocketIO } from './lib/use-socket-io';
+
 export default useWebSocket;

--- a/src/lib/use-socket-io.js
+++ b/src/lib/use-socket-io.js
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import { useWebSocket } from './use-websocket'
+
+const emptyEvent = {
+  type: 'empty',
+  payload: null,
+}
+
+const getSocketData = (event) => {
+  if (!event || !event.data) {
+    return emptyEvent
+  }
+
+  const match = event.data.match(/\[.*]/)
+
+  if (!match) {
+    return emptyEvent
+  }
+
+  const data = JSON.parse(match)
+
+  if (!Array.isArray(data) || !data[1]) {
+    return emptyEvent
+  }
+
+  return {
+    type: data[0],
+    payload: data[1],
+  }
+}
+
+export const useSocketIO = (url, options = DEFAULT_OPTIONS) => {
+  const [ sendMessage, lastMessage, readyStateFromUrl ] = useWebSocket(
+    url,
+    options,
+  )
+
+  return [
+    sendMessage,
+    useMemo(() => getSocketData(lastMessage), [lastMessage]),
+    readyStateFromUrl,
+  ]
+}


### PR DESCRIPTION
in response to #8 

@robtaussig Here is something to start talking about regarding expanding socket-io support out of the box.

I am not too use about the return type - `{ type, payload }` - since it might introduce inconsistencies with the rest of the API. I'll let you decide - let me know and I'll update accordingly.

On another (and slightly related) note, it would be nice to extend this further and add support for rooms and also a subscription like API (not speicifc too socket.io) along the lines of:

```js
const Test = () => {
	const [send, event, ready, socket] = useSocketIO(url, opts)

	const [user] = socket.listen('user updated')
	const [cats] = socket.listen('cat added')

	return <div />
}
```

where `socket.listen` wraps a socket event in a `useState` hook or something along those lines.