### PR TITLE
tsconfig.json has declaration=true to output .d.ts declaration files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "jsx": "react",
       "skipLibCheck": true,
       "lib": ["es2017"],
-      "types" : ["node", "websocket"]
+      "types" : ["node", "websocket"],
+      "declaration": true 
   },
   "baseUrl": ".",
   "files": [


### PR DESCRIPTION
I added this library has a dependency using npm, then went to require it in a typescript project, but npm doesn't have the `*.d.ts` declaration files, so the compiler can't find them.

This adds them.

Thanks for making/sharing the lib.