### PR TITLE
Fix circular dependency of ReadyState imported from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,6 @@ import { useWebSocket } from './lib/use-websocket';
 
 export { useSocketIO } from './lib/use-socket-io';
 
-export enum ReadyState {
-  CONNECTING = 0,
-  OPEN = 1,
-  CLOSING = 2,
-  CLOSED = 3,
-}
+export { ReadyState } from './lib/constants';
 
 export default useWebSocket;

--- a/src/lib/add-subscriber.ts
+++ b/src/lib/add-subscriber.ts
@@ -1,7 +1,7 @@
 import { sharedWebSockets } from './globals';
 import { Setters } from './attach-listener';
 import { ReadyStateState, Options } from './use-websocket';
-import { ReadyState } from '../';
+import { ReadyState } from './constants';
 
 export type Subscriber = {
   setLastMessage: (message: WebSocketEventMap['message']) => void,

--- a/src/lib/attach-listener.ts
+++ b/src/lib/attach-listener.ts
@@ -1,9 +1,8 @@
 import { MutableRefObject } from 'react';
 import { setUpSocketIOPing } from './socket-io';
-import { DEFAULT_RECONNECT_LIMIT, DEFAULT_RECONNECT_INTERVAL_MS } from './constants';
+import { DEFAULT_RECONNECT_LIMIT, DEFAULT_RECONNECT_INTERVAL_MS, ReadyState } from './constants';
 import { addSubscriber } from './add-subscriber';
 import { ReadyStateState, Options } from './use-websocket';
-import { ReadyState } from './constants';
 
 export interface Setters {
   setLastMessage: (message: WebSocketEventMap['message']) => void;

--- a/src/lib/attach-listener.ts
+++ b/src/lib/attach-listener.ts
@@ -3,7 +3,7 @@ import { setUpSocketIOPing } from './socket-io';
 import { DEFAULT_RECONNECT_LIMIT, DEFAULT_RECONNECT_INTERVAL_MS } from './constants';
 import { addSubscriber } from './add-subscriber';
 import { ReadyStateState, Options } from './use-websocket';
-import { ReadyState } from '../';
+import { ReadyState } from './constants';
 
 export interface Setters {
   setLastMessage: (message: WebSocketEventMap['message']) => void;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,3 +8,10 @@ export const SOCKET_IO_PATH = '/socket.io/?EIO=3&transport=websocket';
 export const SOCKET_IO_PING_CODE = '2';
 export const DEFAULT_RECONNECT_LIMIT = 20;
 export const DEFAULT_RECONNECT_INTERVAL_MS = 5000;
+
+export enum ReadyState {
+  CONNECTING = 0,
+  OPEN = 1,
+  CLOSING = 2,
+  CLOSED = 3,
+}

--- a/src/lib/create-or-join.ts
+++ b/src/lib/create-or-join.ts
@@ -1,7 +1,7 @@
 import { MutableRefObject } from 'react';
 import { sharedWebSockets } from './globals';
 import { ReadyStateState, Options } from './use-websocket';
-import { ReadyState } from '../';
+import { ReadyState } from './constants';
 
 export const createOrJoinSocket = (
   webSocketRef: MutableRefObject<WebSocket>,

--- a/src/lib/use-socket-io.ts
+++ b/src/lib/use-socket-io.ts
@@ -1,8 +1,7 @@
 import { useMemo } from 'react'
 import { useWebSocket, SendMessage } from './use-websocket'
-import { DEFAULT_OPTIONS } from './constants'
+import { DEFAULT_OPTIONS, ReadyState } from './constants'
 import { Options } from './use-websocket';
-import { ReadyState } from './constants';
 
 export interface SocketIOMessageData {
   type: string,

--- a/src/lib/use-socket-io.ts
+++ b/src/lib/use-socket-io.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useWebSocket, SendMessage } from './use-websocket'
 import { DEFAULT_OPTIONS } from './constants'
 import { Options } from './use-websocket';
-import { ReadyState } from '../';
+import { ReadyState } from './constants';
 
 export interface SocketIOMessageData {
   type: string,

--- a/src/lib/use-websocket.ts
+++ b/src/lib/use-websocket.ts
@@ -1,10 +1,9 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { parseSocketIOUrl, appendQueryParams, QueryParams } from './socket-io';
 import { attachListeners } from './attach-listener';
-import { DEFAULT_OPTIONS } from './constants';
+import { DEFAULT_OPTIONS, ReadyState } from './constants';
 import { createOrJoinSocket } from './create-or-join';
 import websocketWrapper from './proxy';
-import { ReadyState } from './constants';
 
 export interface Options {
   fromSocketIO?: boolean;

--- a/src/lib/use-websocket.ts
+++ b/src/lib/use-websocket.ts
@@ -4,7 +4,7 @@ import { attachListeners } from './attach-listener';
 import { DEFAULT_OPTIONS } from './constants';
 import { createOrJoinSocket } from './create-or-join';
 import websocketWrapper from './proxy';
-import { ReadyState } from '../';
+import { ReadyState } from './constants';
 
 export interface Options {
   fromSocketIO?: boolean;


### PR DESCRIPTION
When building using rollup with this package as a dependency, we get some warnings about circular deoendencies, eg
```
(!) Circular dependencies
node_modules/react-use-websocket/dist/index.js -> node_modules/react-use-websocket/dist/lib/use-websocket.js -> node_modules/react-use-websocket/dist/lib/attach-listener.js -> node_modules/react-use-websocket/dist/lib/add-subscriber.js -> node_modules/react-use-websocket/dist/index.js
```
Moving `ReadyState` into constants and importing from there rather than from the index resolves this.

Thanks for sharing the package! 