### PR TITLE
Export types SendMessage and Options from src/lib/use-websocket.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-websocket",
-  "version": "1.2.0",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
-import { useWebSocket } from './lib/use-websocket';
+export { useWebSocket as default, SendMessage, Options } from './lib/use-websocket';
 
 export { useSocketIO } from './lib/use-socket-io';
 
 export { ReadyState } from './lib/constants';
-
-export default useWebSocket;


### PR DESCRIPTION
This change makes it easier to build application-specific wrappers in TypeScript around `useWebSocket`, as you no longer have to import `SendMessage` and `Options` from inside this module.

Before:

```ts
import useWebSocket, { ReadyState } from 'react-use-websocket';
import { SendMessage, Options } from 'react-use-websocket/src/lib/use-websocket';

function useSharedSocket(options: Omit<Options, 'share'|'queryParams'>): [SendMessage, MessageEvent, ReadyState, () => WebSocket] {
    // ...
}
```

After:

```ts
import useWebSocket, { ReadyState, SendMessage, Options } from 'react-use-websocket';

function useSharedSocket(options: Omit<Options, 'share'|'queryParams'>): [SendMessage, MessageEvent, ReadyState, () => WebSocket] {
    // ...
}