### PR TITLE
Change return values to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import useWebSocket, { ReadyState } from 'react-use-websocket';
 export const WebSocketDemo = () => {
   const [socketUrl, setSocketUrl] = useState('wss://echo.websocket.org'); //Public API that will echo messages sent to it back to the client
   const [messageHistory, setMessageHistory] = useState([]);
-  const [sendMessage, lastMessage, readyState, getWebSocket] = useWebSocket(socketUrl);
+  const { sendMessage, lastMessage, readyState, getWebSocket } = useWebSocket(socketUrl);
 
   const handleClickChangeSocketUrl = useCallback(() => setSocketUrl('wss://demos.kaazing.com/echo'), []);
   const handleClickSendMessage = useCallback(() => sendMessage('Hello'), []);
@@ -78,7 +78,7 @@ const STATIC_OPTIONS = useMemo(() => ({
   shouldReconnect: (closeEvent) => true, //Will attempt to reconnect on all close events, such as server shutting down
 }), []);
 
-const [sendMessage, lastMessage, readyState, getWebSocket] = useWebSocket('wss://echo.websocket.org', STATIC_OPTIONS);
+const { sendMessage, lastMessage, readyState, getWebSocket } = useWebSocket('wss://echo.websocket.org', STATIC_OPTIONS);
 ```
 
 ## Requirements
@@ -113,7 +113,7 @@ const options = useMemo(() =>({
   reconnectInterval: 3000,
 }, []);
 
-const [sendMessage, lastMessage, readyState] = useWebSocket('wss://echo.websocket.org', options);
+const { sendMessage, lastMessage, readyState } = useWebSocket('wss://echo.websocket.org', options);
 
 useEffect(() => {
   return () => {
@@ -127,7 +127,7 @@ useEffect(() => {
 Calling this function will lazily instantiate a Proxy instance that wraps the underlying websocket. You can get and set properties on the return value that will directly interact with the websocket, however certain properties/methods are protected (cannot invoke `close` or `send`, and cannot redefine any of the event handlers like `onmessage`, `onclose`, `onopen` and `onerror`. An example of using this:
 
 ```js
-const [sendMessage, lastMessage, readyState, getWebSocket] = useWebSocket('wss://echo.websocket.org');
+const { sendMessage, lastMessage, readyState, getWebSocket } = useWebSocket('wss://echo.websocket.org');
 
 //Run on mount
 useEffect(() => {
@@ -175,7 +175,7 @@ const options = useMemo(() => ({
   shouldReconnect: () => dynamicPropRef.current === true, //If websocket closing is intentional, can set dynamicPropRef to false to avoid unnecessary reconnect attempts
 }),[]);
 
-const [sendMessage, lastMessage, readyState] = useWebSocket('wss://echo.websocket.org', options);
+const { sendMessage, lastMessage, readyState } = useWebSocket('wss://echo.websocket.org', options);
 ```
 
 ### ShouldReconnect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-websocket",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1185,9 +1185,9 @@
       }
     },
     "@types/node": {
-      "version": "12.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+      "version": "12.12.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
+      "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==",
       "dev": true
     },
     "@types/prop-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-websocket",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "React Hook for WebSocket communication",
   "main": "./dist/index.js",
   "files": [
@@ -22,9 +22,9 @@
     "@babel/core": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
+    "@types/node": "^12.12.30",
     "@types/react": "^16.8.23",
     "@types/react-dom": "^16.8.5",
-    "@types/node": "^12.6.8",
     "@types/websocket": "0.0.40",
     "awesome-typescript-loader": "^5.2.1",
     "babel-core": "^7.0.0-bridge.0",

--- a/src/lib/use-socket-io.ts
+++ b/src/lib/use-socket-io.ts
@@ -45,7 +45,7 @@ export const useSocketIO = (
     fromSocketIO: true,
   }), [])
 
-  const [ sendMessage, lastMessage, readyStateFromUrl, getWebSocket ] = useWebSocket(
+  const { sendMessage, lastMessage, readyStateFromUrl, getWebSocket } = useWebSocket(
     url,
     optionsWithSocketIO,
   )


### PR DESCRIPTION
Relates to #30.
This change reduces coupling between `useWebsocket` return and usage.
Today the return values is an array with `sendMessage`, `lastMessage`, `readyState`, `getWebSocket` , in that order. Returning an object allows to pick any return value, in any order.