### PR TITLE
Feature: Add subprotocol option

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ interface Options {
   queryParams?: {
     [key: string]: string | number;
   };
+  protocols?: string | string[]
 }
 ```
 ### shouldReconnect

--- a/src/lib/create-or-join.ts
+++ b/src/lib/create-or-join.ts
@@ -19,7 +19,7 @@ export const createOrJoinSocket = (
   if (optionsRef.current.share) {
     if (sharedWebSockets[url] === undefined) {
       setReadyState(prev => Object.assign({}, prev, {[url]: ReadyState.CONNECTING }));
-      sharedWebSockets[url] = new WebSocket(url);
+      sharedWebSockets[url] = new WebSocket(url, optionsRef.current.protocols);
       attachSharedListeners(sharedWebSockets[url], url);
     } else {
       setReadyState(prev => Object.assign({}, prev, {[url]: sharedWebSockets[url].readyState }));
@@ -51,7 +51,7 @@ export const createOrJoinSocket = (
     };
   } else {
     setReadyState(prev => Object.assign({}, prev, {[url]: ReadyState.CONNECTING }));
-    webSocketRef.current = new WebSocket(url);
+    webSocketRef.current = new WebSocket(url, optionsRef.current.protocols);
 
     return attachListeners(
       webSocketRef.current,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ export interface QueryParams {
 export interface Options {
   fromSocketIO?: boolean;
   queryParams?: QueryParams;
+  protocols?: string | string[];
   share?: boolean;
   onOpen?: (event: WebSocketEventMap['open']) => void;
   onClose?: (event: WebSocketEventMap['close']) => void;


### PR DESCRIPTION
Add option to support websocket subprotocol that can set at 2nd argument of WebSocket constructor.

```typescript
declare var WebSocket: {
    new(url: string, protocols?: string | string[]): WebSocket;
};
```
