### PR TITLE
Strict mode support

### DIFF
--- a/src/lib/attach-shared-listeners.ts
+++ b/src/lib/attach-shared-listeners.ts
@@ -33,7 +33,7 @@ export const attachSharedListeners = (
       subscriber.setReadyState(ReadyState.CLOSED);
     });
     
-    sharedWebSockets[url] = undefined;
+    delete sharedWebSockets[url];
 
     getSubscribers(url).forEach(subscriber => {
       if (

--- a/src/lib/create-or-join.ts
+++ b/src/lib/create-or-join.ts
@@ -7,7 +7,7 @@ import { attachSharedListeners } from './attach-shared-listeners';
 import { addSubscriber, removeSubscriber, hasSubscribers } from './manage-subscribers';
 
 export const createOrJoinSocket = (
-  webSocketRef: MutableRefObject<WebSocket>,
+  webSocketRef: MutableRefObject<WebSocket | null>,
   url: string,
   setReadyState: (readyState: ReadyState) => void,
   optionsRef: MutableRefObject<Options>,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,8 +41,8 @@ export type Subscriber<T = WebSocketEventMap['message']> = {
 export type WebSocketHook<T = WebSocketEventMap['message']> = {
   sendMessage: SendMessage,
   sendJsonMessage: SendJsonMessage,
-  lastMessage: T,
+  lastMessage: T | null,
   lastJsonMessage: any,
   readyState: ReadyState,
-  getWebSocket: () => WebSocket,
+  getWebSocket: () => (WebSocket | null),
 }

--- a/src/lib/use-socket-io.ts
+++ b/src/lib/use-socket-io.ts
@@ -13,7 +13,7 @@ const emptyEvent: SocketIOMessageData = {
   payload: null,
 }
 
-const getSocketData = (event: WebSocketEventMap['message']): SocketIOMessageData => {
+const getSocketData = (event: WebSocketEventMap['message'] | null): SocketIOMessageData => {
   if (!event || !event.data) {
     return emptyEvent
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
       "outDir": "./dist/",
       "sourceMap": true,
-      "noImplicitAny": true,
       "module": "commonjs",
       "target": "es5",
       "jsx": "react",
       "skipLibCheck": true,
       "lib": ["es2017", "dom"],
       "types" : ["node", "websocket"],
+      "strict": true,
       "declaration": true 
   },
   "baseUrl": ".",


### PR DESCRIPTION
Hi!

Once I got a runtime error while trying to execute a command `getWebSocket().close()`. However, this could not have happened according to the types. Then I noticed that this package was built with strict mode turned off. So I tried to enable strict mode and fix the errors.

Please see what came of it. I am ready to comment on my decisions.