### PR TITLE
Fix TypeError: message is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export const WebSocketDemo = () => {
       {lastMessage ? <span>Last message: {lastMessage.data}</span> : null}
       <ul>
         {messageHistory.current
-          .map((message, idx) => <span key={idx}>{message.data}</span>)}
+          .map((message, idx) => <span key={idx}>{message ? message.data : null}</span>)}
       </ul>
     </div>
   );


### PR DESCRIPTION
I was getting a "TypeError: message is null" error when using the wss://echo.websocket.org endpoint before the page would display for the first time.
