### PR TITLE
Add 'types' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "git+https://github.com/robtaussig/react-use-websocket.git"
   },
   "dependencies": {},
+  "types": "./dist/index.d.ts",
   "peerDependencies": {
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0"


### PR DESCRIPTION
Hi, I hope this is the right way to contribute here -- it seemed like a small enough suggestion that a preceding issue would have been too much.

I'm currently experimenting with a react project using [deno](https://deno.land/), but I can't import the types for `react-use-websocket`. This isn't terribly surprising since [deno has its own rules](https://deno.land/manual@v1.12.2/npm_nodejs), and as a result I have been importing `react-use-websocket` via either [esm.sh](https://esm.sh/) or [skypack](https://www.skypack.dev/) which are deno-friendly CDNs that pull from the npm registry.

While investigating, I found the change submitted in this PR, which is strongly encouraged in both the [typescript docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package) and the [skypack docs](https://docs.skypack.dev/package-authors/package-checks#types).

I think npm pulls from the built `/dist` folder whether or not this field is specified, but this change should help other CDNs find and support this repository's types. Thanks for your time!