### PR TITLE
Reset reconnect count on request to not connect.

### DIFF
--- a/src/lib/use-websocket.ts
+++ b/src/lib/use-websocket.ts
@@ -131,6 +131,7 @@ export const useWebSocket = (
         setLastMessage(null);
       };
     } else if (url === null || connect === false) {
+      reconnectCount.current = 0; // reset reconnection attempts
       setReadyState(prev => ({
         ...prev,
         ...(convertedUrl.current && {[convertedUrl.current]: ReadyState.CLOSED}),


### PR DESCRIPTION
Hi there,

I've got a particular use-case where the connect flag changes from time to time, but when its re-enabled, it's expected that the reconnect count will have reset. Is this a reasonable change and request?

Thanks!