### PR TITLE
Race condition: webSocketRef.current can be null when using share option

### DIFF
--- a/src/lib/create-or-join.ts
+++ b/src/lib/create-or-join.ts
@@ -59,6 +59,8 @@ export const createOrJoinSocket = (
 
   if (optionsRef.current.share) {
     let clearSocketIoPingInterval: ((() => void) | null) = null;
+    webSocketRef.current = sharedWebSockets[url];
+
     if (sharedWebSockets[url] === undefined) {
       setReadyState(ReadyState.CONNECTING);
       sharedWebSockets[url] = optionsRef.current.eventSourceOptions ?
@@ -83,7 +85,6 @@ export const createOrJoinSocket = (
     };
   
     addSubscriber(url, subscriber);
-    webSocketRef.current = sharedWebSockets[url];
 
     return cleanSubscribers(
       url,


### PR DESCRIPTION
Was trying out this lib together with react router (browser router with forceRefresh) but couldn't get the `share` option to work for some reason. First component (and any mounted at the same time) always works fine and I can see traffic from the websocket but any other components reusing the same URL at a later stage fails silently (no errors or anything 🤔 ). 

I dug and found it seems to set the ready state before assigning the socket:
https://github.com/robtaussig/react-use-websocket/blob/master/src/lib/create-or-join.ts#L74
https://github.com/robtaussig/react-use-websocket/blob/master/src/lib/create-or-join.ts#L86

Swapping the order `webSocketRef.current = sharedWebSockets[url];` to be executed before the `setReadyState...` state works! Also tested by adding a short delay after the ready state has been set (in order for the ref to have time be set) and confirms that it works.

Thoughts?