### PR TITLE
Disconnect on request to not connect

### DIFF
--- a/src/lib/use-websocket.ts
+++ b/src/lib/use-websocket.ts
@@ -131,6 +131,9 @@ export const useWebSocket = (
         setLastMessage(null);
       };
     } else if (url === null || connect === false) {
+      if (webSocketRef.current?.readyState === ReadyState.OPEN) {
+        webSocketRef.current.close()
+      }
       reconnectCount.current = 0; // reset reconnection attempts
       setReadyState(prev => ({
         ...prev,


### PR DESCRIPTION
Maybe I'm misunderstanding how to use the library but I could not find a way to manually disconnect a shared socket.

From the docs it seemed that passing `connect=false` (or `url=null`) would be the expected way, and in fact in the only code branch for that condition we do set the hook's `readyState` to closed, but the socket itself is not closed.

If this change makes sense, I'm glad to address any misses (e.g. probably we should `close()` also on `ReadyState.CONNECTING`), repercussions and tests. Thanks for the work on the library!