### PR TITLE
ADDED socketIOPingInterval option to allow users to customise ping interval

### DIFF
--- a/src/lib/attach-shared-listeners.ts
+++ b/src/lib/attach-shared-listeners.ts
@@ -115,7 +115,7 @@ export const attachSharedListeners = (
   let interval: number;
 
   if (optionsRef.current.fromSocketIO) {
-    interval = setUpSocketIOPing(sendMessage);
+    interval = setUpSocketIOPing(sendMessage, optionsRef.current.socketIOPingInterval);
   }
 
   bindMessageHandler(webSocketInstance, url);


### PR DESCRIPTION
Some SocketIO implementations have shorter ping interval requirements than the current fixed value constant. 

This PR exposes a `socketIOPingInterval` option which if `fromSocketIO` is true will pass a custom ping length down to `setUpSocketIOPing`.

It looks like most of the code was already implemented, and only required a single line change to allow the option to be passed in. 