### PR TITLE
Allow for an infinite number of reconnect attempts

### DIFF
--- a/src/lib/attach-listener.ts
+++ b/src/lib/attach-listener.ts
@@ -59,7 +59,8 @@ const bindCloseHandler = (
     setReadyState(ReadyState.CLOSED);
     if (optionsRef.current.shouldReconnect && optionsRef.current.shouldReconnect(event)) {
       const reconnectAttempts = optionsRef.current.reconnectAttempts ?? DEFAULT_RECONNECT_LIMIT;
-      if (reconnectCount.current < reconnectAttempts) {
+          // Check if reconnectAttempts is still belof the current number of reconnects, or if its -1 (infinite)
+      if (reconnectCount.current < reconnectAttempts || reconnectAttempts === -1) {
         const nextReconnectInterval = typeof optionsRef.current.reconnectInterval === 'function' ?
           optionsRef.current.reconnectInterval(reconnectCount.current) :
           optionsRef.current.reconnectInterval;
@@ -100,7 +101,7 @@ const bindErrorHandler = (
       setReadyState(ReadyState.CLOSED);
       webSocketInstance.close();
     }
-    
+
     if (optionsRef.current.retryOnError) {
       if (reconnectCount.current < (optionsRef.current.reconnectAttempts ?? DEFAULT_RECONNECT_LIMIT)) {
         const nextReconnectInterval = typeof optionsRef.current.reconnectInterval === 'function' ?

--- a/src/lib/attach-shared-listeners.ts
+++ b/src/lib/attach-shared-listeners.ts
@@ -53,19 +53,20 @@ const bindCloseHandler = (
         if (subscriber.optionsRef.current.onClose) {
           subscriber.optionsRef.current.onClose(event);
         }
-  
+
         subscriber.setReadyState(ReadyState.CLOSED);
       });
-      
+
       delete sharedWebSockets[url];
-  
+
       getSubscribers(url).forEach(subscriber => {
         if (
           subscriber.optionsRef.current.shouldReconnect &&
           subscriber.optionsRef.current.shouldReconnect(event)
         ) {
           const reconnectAttempts = subscriber.optionsRef.current.reconnectAttempts ?? DEFAULT_RECONNECT_LIMIT;
-          if (subscriber.reconnectCount.current < reconnectAttempts) {
+          // Check if reconnectAttempts is still belof the current number of reconnects, or if its -1 (infinite)
+          if (subscriber.reconnectCount.current < reconnectAttempts || reconnectAttempts === -1) {
             const nextReconnectInterval = typeof subscriber.optionsRef.current.reconnectInterval === 'function' ?
               subscriber.optionsRef.current.reconnectInterval(subscriber.reconnectCount.current) :
               subscriber.optionsRef.current.reconnectInterval;
@@ -100,7 +101,7 @@ const bindErrorHandler = (
           reason: `An error occurred with the EventSource: ${error}`,
           wasClean: false,
         });
-  
+
         subscriber.setReadyState(ReadyState.CLOSED);
       }
     });


### PR DESCRIPTION
To use an infinite amount of reconnect attempts, `"reconnectAttempts"` in the `Options` object, should be provided with value `-1`.