### PR TITLE
Fix a bug which lead no overload matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import useWebSocket, { ReadyState } from 'react-use-websocket';
 export const WebSocketDemo = () => {
   //Public API that will echo messages sent to it back to the client
   const [socketUrl, setSocketUrl] = useState('wss://echo.websocket.org');
-  const [messageHistory, setMessageHistory] = useState([]);
+  const [messageHistory, setMessageHistory] = useState<MessageEvent<any>[]>([]);
 
   const { sendMessage, lastMessage, readyState } = useWebSocket(socketUrl);
 


### PR DESCRIPTION
This pr fix a example bug for ts with a react >=18.2. It tuns like this:
```
TS2769: No overload matches this call.
  Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.
    Argument of type 'MessageEvent<any>' is not assignable to parameter of type 'ConcatArray<never>'.  
      Type 'MessageEvent<any>' is missing the following properties from type 'ConcatArray<never>': length, join, slice
  Overload 2 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.
    Argument of type 'MessageEvent<any>' is not assignable to parameter of type 'ConcatArray<never>'.  
    11 |     useEffect(() => {
    12 |         if (lastMessage !== null) {
  > 13 |           setMessageHistory((prev) => prev.concat(lastMessage));
       |                                                   ^^^^^^^^^^^
    14 |         }
    15 |       }, [lastMessage, setMessageHistory]);
```