### PR TITLE
feat: allow ping message to be dynamically created

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ type UseWebSocket<T = unknown> = (
     retryOnError?: boolean;
     eventSourceOptions?: EventSourceInit;
     heartbeat?: boolean | {
-      message?: "ping" | "pong" | string;
+      message?: "ping" | "pong" | string | (() => string);
       returnMessage?: "ping" | "pong" | string;
       timeout?: number;
       interval?: number;

--- a/src/lib/heartbeat.test.ts
+++ b/src/lib/heartbeat.test.ts
@@ -58,4 +58,18 @@ describe("heartbeat", () => {
     jest.advanceTimersByTime(25000);
     expect(sendSpy).toHaveBeenCalledWith("pong");
   });
+
+  test("sends a ping message using a function", () => {
+    let id = 0;
+    function nextPing() {
+      return 'msg' + (id++);
+    }
+
+    heartbeat(ws, { message: nextPing, interval: 100 });
+    expect(sendSpy).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(101);
+    expect(sendSpy).toHaveBeenCalledWith('msg0');
+    jest.advanceTimersByTime(100);
+    expect(sendSpy).toHaveBeenCalledWith('msg1');
+  });
 });

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -12,7 +12,12 @@ export function heartbeat(ws: WebSocket, options?: HeartbeatOptions): () => void
 
   const pingTimer = setInterval(() => {
     try {
-      ws.send(message);
+      if (typeof message === 'function') {
+        ws.send(message());
+      }
+      else {
+        ws.send(message);
+      }
     } catch (error) {
       // do nothing
     }

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -14,8 +14,7 @@ export function heartbeat(ws: WebSocket, options?: HeartbeatOptions): () => void
     try {
       if (typeof message === 'function') {
         ws.send(message());
-      }
-      else {
+      } else {
         ws.send(message);
       }
     } catch (error) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,7 @@ export interface Options {
 export type EventSourceOnly = Omit<Options, 'eventSourceOptions'> & EventSourceInit;
 
 export type HeartbeatOptions = {
-  message?: "ping" | "pong" | string;
+  message?: "ping" | "pong" | string | (() => string);
   returnMessage?: "ping" | "pong" | string;
   timeout?: number;
   interval?: number;


### PR DESCRIPTION
This change allows `heartbeat.message` to accept a function which returns a string

My use-case is to send a ping which includes the send time from the client's perspective 

```json
{"_type": "ping", "timestamp": "2016-06-03T23:15:33.008Z"}
```

e.g.

```javascript
useWebsocket(url, {
    heartbeat: {
        message: () => JSON.stringify({ type: 'ping', timestamp: currentTime() })
    }
}
```
