### PR TITLE
Fix console warning including 'undefined' and a type violation

### DIFF
--- a/src/lib/attach-listener.ts
+++ b/src/lib/attach-listener.ts
@@ -121,7 +121,8 @@ const bindErrorHandler = (
     }
     
     if (optionsRef.current.retryOnError) {
-      if (reconnectCount.current < (optionsRef.current.reconnectAttempts ?? DEFAULT_RECONNECT_LIMIT)) {
+      const reconnectAttempts = optionsRef.current.reconnectAttempts ?? DEFAULT_RECONNECT_LIMIT;
+      if (reconnectCount.current < reconnectAttempts) {
         const nextReconnectInterval = typeof optionsRef.current.reconnectInterval === 'function' ?
           optionsRef.current.reconnectInterval(reconnectCount.current) :
           optionsRef.current.reconnectInterval;
@@ -131,8 +132,8 @@ const bindErrorHandler = (
           reconnect();
         }, nextReconnectInterval ?? DEFAULT_RECONNECT_INTERVAL_MS);
       } else {
-        optionsRef.current.onReconnectStop && optionsRef.current.onReconnectStop(optionsRef.current.reconnectAttempts as number);
-        console.warn(`Max reconnect attempts of ${optionsRef.current.reconnectAttempts} exceeded`);
+        optionsRef.current.onReconnectStop && optionsRef.current.onReconnectStop(reconnectAttempts);
+        console.warn(`Max reconnect attempts of ${reconnectAttempts} exceeded`);
       }
     }
   };


### PR DESCRIPTION
This fixes the following console warning including 'undefined', if the user never specifies that config option

    console.warn(`Max reconnect attempts of ${optionsRef.current.reconnectAttempts} exceeded`);

There's another instance of the same warning which null-coalesces the default of 20 before printing, which is more sensible.

It also fixes this typecast being wrong. `optionsRef.current.reconnectAttempts` is possibly undefined, and `onReconnectStop` is not declared to accept that (hence the cast, I guess).

    optionsRef.current.onReconnectStop && optionsRef.current.onReconnectStop(optionsRef.current.reconnectAttempts as number);

After I'd changed that, my IDE warned me that reconnect section was an exact duplicate. I don't always pay attention to that warning, but since there were 2 functions doing the same thing, one with bugs and one without, it seemed a good candidate to extract to new a function so that they don't diverge again.

This change is split into 2 commits: the functional change to fix the bugs, then the refactor. 

@robtaussig Please review!