### PR TITLE
Improve heartbeat

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,6 @@
   "bugs": {
     "url": "https://github.com/robtaussig/react-use-websocket/issues"
   },
-  "homepage": "https://github.com/robtaussig/react-use-websocket#readme"
+  "homepage": "https://github.com/robtaussig/react-use-websocket#readme",
+  "packageManager": "yarn@4.5.0"
 }

--- a/src/lib/attach-listener.test.ts
+++ b/src/lib/attach-listener.test.ts
@@ -10,6 +10,7 @@ const noop = () => { };
 const DEFAULT_OPTIONS: Options = {};
 let client: WebSocket;
 let reconnectCountRef: MutableRefObject<number>;
+let lastMessageTimeRef: MutableRefObject<number>;
 let optionRef: MutableRefObject<Options>;
 const sleep = (duration: number): Promise<void> => new Promise(resolve => setTimeout(() => resolve(), duration));
 
@@ -33,6 +34,7 @@ test('It returns a cleanup function that closes the websocket', () => {
         optionRef,
         noop,
         reconnectCountRef,
+        lastMessageTimeRef,
         noop,
     );
 
@@ -50,6 +52,7 @@ test('Messages received by the webwsocket are passed to the lastMessageSetter', 
         optionRef,
         noop,
         reconnectCountRef,
+        lastMessageTimeRef,
         noop,
     );
 
@@ -67,6 +70,7 @@ test('The readyState setter is called when the websocket connection is open', ()
         optionRef,
         noop,
         reconnectCountRef,
+        lastMessageTimeRef,
         noop,
     );
 
@@ -84,6 +88,7 @@ test('It attempts to reconnect up to specified reconnect attempts', async () => 
             optionRef,
             reconnect,
             reconnectCountRef,
+            lastMessageTimeRef,
             noop,
         );
     });
@@ -97,6 +102,7 @@ test('It attempts to reconnect up to specified reconnect attempts', async () => 
         optionRef,
         reconnect,
         reconnectCountRef,
+        lastMessageTimeRef,
         noop,
     );
 
@@ -116,6 +122,7 @@ test('It accepts a function for reconnectInterval to customize the timing of rec
             optionRef,
             reconnect,
             reconnectCountRef,
+            lastMessageTimeRef,
             noop,
         );
     });
@@ -129,19 +136,20 @@ test('It accepts a function for reconnectInterval to customize the timing of rec
         optionRef,
         reconnect,
         reconnectCountRef,
+        lastMessageTimeRef,
         noop,
     );
 
     await sleep(1000);
     server.close();
     await sleep(1000);
-    
+
     //100 + 200 + 400 = 700 -- a 4th attempt would take 800ms, totalling 1500ms which would exceed the 1000ms since the server closed
     expect(reconnect).toHaveBeenCalledTimes(3);
 })
 
 test('When server closes the websocket, readyState transitions immediately to CLOSED', async () => {
-    const setReadyStateFn = jest.fn((readyState: ReadyState) => {});
+    const setReadyStateFn = jest.fn((readyState: ReadyState) => { });
 
     attachListeners(
         client,
@@ -149,6 +157,7 @@ test('When server closes the websocket, readyState transitions immediately to CL
         optionRef,
         noop,
         reconnectCountRef,
+        lastMessageTimeRef,
         noop,
     );
     await sleep(1000);
@@ -160,14 +169,15 @@ test('When server closes the websocket, readyState transitions immediately to CL
 })
 
 test('When client closes the websocket using the provided cleanup function, readyState transitions to CLOSING and then to CLOSED', async () => {
-    const setReadyStateFn = jest.fn((readyState: ReadyState) => {});
-    
+    const setReadyStateFn = jest.fn((readyState: ReadyState) => { });
+
     const cleanup = attachListeners(
         client,
         { setLastMessage: noop, setReadyState: setReadyStateFn },
         optionRef,
         noop,
         reconnectCountRef,
+        lastMessageTimeRef,
         noop,
     );
 

--- a/src/lib/attach-shared-listeners.test.ts
+++ b/src/lib/attach-shared-listeners.test.ts
@@ -15,6 +15,7 @@ let client: WebSocket;
 let subscriber1: Subscriber;
 let subscriber2: Subscriber;
 let reconnectCountRef: MutableRefObject<number>;
+let lastMessageTimeRef: MutableRefObject<number>;
 let optionRef: MutableRefObject<Options>;
 
 beforeEach(async () => {
@@ -33,6 +34,7 @@ beforeEach(async () => {
     setReadyState: noop,
     optionsRef: optionRef,
     reconnectCount: reconnectCountRef,
+    lastMessageTime: lastMessageTimeRef,
     reconnect: { current: noop },
   }
 
@@ -41,6 +43,7 @@ beforeEach(async () => {
     setReadyState: noop,
     optionsRef: optionRef,
     reconnectCount: reconnectCountRef,
+    lastMessageTime: lastMessageTimeRef,
     reconnect: { current: noop },
   }
 

--- a/src/lib/create-or-join.test.ts
+++ b/src/lib/create-or-join.test.ts
@@ -11,6 +11,7 @@ const noop = () => { };
 const DEFAULT_OPTIONS: Options = { share: true };
 let clientRef: MutableRefObject<WebSocket>;
 let reconnectCountRef: MutableRefObject<number>;
+let lastMessageTimeRef: MutableRefObject<number>;
 let optionRef: MutableRefObject<Options>;
 let noopRef: MutableRefObject<typeof noop>;
 
@@ -31,7 +32,7 @@ afterEach(() => {
 
 test('It only creates 1 websocket per URL and closes websocket when no subscribers are left', () => {
   clientRef = { current: new WebSocket(URL) };
-  const closeFn = jest.fn(() => {});
+  const closeFn = jest.fn(() => { });
 
   const cleanup1 = createOrJoinSocket(
     clientRef,
@@ -41,6 +42,7 @@ test('It only creates 1 websocket per URL and closes websocket when no subscribe
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
   const cleanup2 = createOrJoinSocket(
@@ -51,6 +53,7 @@ test('It only creates 1 websocket per URL and closes websocket when no subscribe
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
   const cleanup3 = createOrJoinSocket(
@@ -61,6 +64,7 @@ test('It only creates 1 websocket per URL and closes websocket when no subscribe
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
 
@@ -82,7 +86,7 @@ test('It only creates 1 websocket per URL and closes websocket when no subscribe
 test('All subscriber option-based onClose callbacks are invoked per close event', () => {
   clientRef = { current: new WebSocket(URL) };
 
-  const onCloseFn = jest.fn(() => {});
+  const onCloseFn = jest.fn(() => { });
 
   optionRef.current.onClose = onCloseFn;
 
@@ -94,9 +98,10 @@ test('All subscriber option-based onClose callbacks are invoked per close event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -105,9 +110,10 @@ test('All subscriber option-based onClose callbacks are invoked per close event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -116,20 +122,21 @@ test('All subscriber option-based onClose callbacks are invoked per close event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
 
   expect(onCloseFn).toHaveBeenCalledTimes(0);
 
   server.close();
-  
+
   expect(onCloseFn).toHaveBeenCalledTimes(3);
 });
 
 test('All subscriber option-based onError callbacks are not invoked on close event', () => {
   clientRef = { current: new WebSocket(URL) };
 
-  const onErrorFn = jest.fn(() => {});
+  const onErrorFn = jest.fn(() => { });
 
   optionRef.current.onError = onErrorFn;
 
@@ -141,9 +148,10 @@ test('All subscriber option-based onError callbacks are not invoked on close eve
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -152,9 +160,10 @@ test('All subscriber option-based onError callbacks are not invoked on close eve
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -163,19 +172,20 @@ test('All subscriber option-based onError callbacks are not invoked on close eve
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
 
 
   server.close();
-  
+
   expect(onErrorFn).toHaveBeenCalledTimes(0);
 });
 
 test('All subscriber option-based onMessage callbacks are invoked per message event', () => {
   clientRef = { current: new WebSocket(URL) };
 
-  const onMessageFn = jest.fn(() => {});
+  const onMessageFn = jest.fn(() => { });
 
   optionRef.current.onMessage = onMessageFn;
 
@@ -187,9 +197,10 @@ test('All subscriber option-based onMessage callbacks are invoked per message ev
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -198,9 +209,10 @@ test('All subscriber option-based onMessage callbacks are invoked per message ev
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -209,6 +221,7 @@ test('All subscriber option-based onMessage callbacks are invoked per message ev
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
 
@@ -218,14 +231,14 @@ test('All subscriber option-based onMessage callbacks are invoked per message ev
   server.send('Hello');
   server.send('There');
   server.close();
-  
+
   expect(onMessageFn).toHaveBeenCalledTimes(6);
 });
 
 test('All subscriber option-based onError callbacks are invoked per error event', () => {
   clientRef = { current: new WebSocket(URL) };
 
-  const onErrorFn = jest.fn(() => {});
+  const onErrorFn = jest.fn(() => { });
 
   optionRef.current.onError = onErrorFn;
 
@@ -237,9 +250,10 @@ test('All subscriber option-based onError callbacks are invoked per error event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -248,9 +262,10 @@ test('All subscriber option-based onError callbacks are invoked per error event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -259,21 +274,22 @@ test('All subscriber option-based onError callbacks are invoked per error event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
 
   expect(onErrorFn).toHaveBeenCalledTimes(0);
 
   server.error();
-  
+
   expect(onErrorFn).toHaveBeenCalledTimes(3);
 });
 
 test('All subscriber option-based onClose callbacks are invoked per error event', () => {
   clientRef = { current: new WebSocket(URL) };
 
-  const onErrorFn = jest.fn(() => {});
-  const onCloseFn = jest.fn(() => {});
+  const onErrorFn = jest.fn(() => { });
+  const onCloseFn = jest.fn(() => { });
 
   optionRef.current.onError = onErrorFn;
   optionRef.current.onClose = onCloseFn;
@@ -286,9 +302,10 @@ test('All subscriber option-based onClose callbacks are invoked per error event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -297,9 +314,10 @@ test('All subscriber option-based onClose callbacks are invoked per error event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
-  
+
   createOrJoinSocket(
     clientRef,
     URL,
@@ -308,6 +326,7 @@ test('All subscriber option-based onClose callbacks are invoked per error event'
     noop,
     noopRef,
     reconnectCountRef,
+    lastMessageTimeRef,
     noop,
   );
 
@@ -315,7 +334,7 @@ test('All subscriber option-based onClose callbacks are invoked per error event'
   expect(onCloseFn).toHaveBeenCalledTimes(0);
 
   server.error();
-  
+
   expect(onErrorFn).toHaveBeenCalledTimes(3);
   expect(onCloseFn).toHaveBeenCalledTimes(3);
 });

--- a/src/lib/create-or-join.ts
+++ b/src/lib/create-or-join.ts
@@ -47,6 +47,7 @@ export const createOrJoinSocket = (
   setLastMessage: (message: WebSocketEventMap['message']) => void,
   startRef: MutableRefObject<() => void>,
   reconnectCount: MutableRefObject<number>,
+  lastMessageTime: MutableRefObject<number>,
   sendMessage: SendMessage,
 ): (() => void) => {
   if (!isEventSourceSupported && optionsRef.current.eventSourceOptions) {
@@ -81,9 +82,10 @@ export const createOrJoinSocket = (
       setReadyState,
       optionsRef,
       reconnectCount,
+      lastMessageTime,
       reconnect: startRef,
     };
-  
+
     addSubscriber(url, subscriber);
 
     return cleanSubscribers(
@@ -111,6 +113,7 @@ export const createOrJoinSocket = (
       optionsRef,
       startRef.current,
       reconnectCount,
+      lastMessageTime,
       sendMessage,
     );
   }

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -1,41 +1,39 @@
+import { MutableRefObject } from "react";
 import { DEFAULT_HEARTBEAT } from "./constants";
 import { HeartbeatOptions } from "./types";
 
-export function heartbeat(ws: WebSocket, options?: HeartbeatOptions): () => void {
+export function heartbeat(ws: WebSocket, lastMessageTime: MutableRefObject<number>, options?: HeartbeatOptions): () => void {
   const {
     interval = DEFAULT_HEARTBEAT.interval,
     timeout = DEFAULT_HEARTBEAT.timeout,
     message = DEFAULT_HEARTBEAT.message,
   } = options || {};
 
-  let messageAccepted = false;
+  const heartbeatInterval = setInterval(() => {
+    if (lastMessageTime.current + timeout <= Date.now()) {
+      console.warn(`Heartbeat timed out, closing connection, last message was seen ${Date.now() - lastMessageTime.current}ms ago`);
+      ws.close();
+    } else {
+      if (lastMessageTime.current + interval <= Date.now()) {
+        try {
+          if (typeof message === 'function') {
+            ws.send(message());
+          } else {
+            ws.send(message);
+          }
+        } catch (err: unknown) {
+          console.error(`Heartbeat failed, closing connection`, err instanceof Error ? err.message : err);
+          ws.close();
+        }
 
-  const pingTimer = setInterval(() => {
-    try {
-      if (typeof message === 'function') {
-        ws.send(message());
-      } else {
-        ws.send(message);
       }
-    } catch (error) {
-      // do nothing
     }
   }, interval);
 
-  const timeoutTimer = setInterval(() => {
-    if (!messageAccepted) {
-      ws.close();
-    } else {
-      messageAccepted = false;
-    }
-  }, timeout);
-
   ws.addEventListener("close", () => {
-    clearInterval(pingTimer);
-    clearInterval(timeoutTimer);
+    clearInterval(heartbeatInterval);
   });
 
-  return () => {
-    messageAccepted = true;
-  };
+
+  return () => { };
 }

--- a/src/lib/manage-subscribers.test.ts
+++ b/src/lib/manage-subscribers.test.ts
@@ -9,13 +9,14 @@ import { Subscriber } from './types';
 
 const URL = 'ws://localhost:1234';
 const SECOND_URL = 'ws://localhost:4321'
-const noop = () => {};
+const noop = () => { };
 
 const subscriber1: Subscriber = {
     setLastMessage: noop,
     setReadyState: noop,
     optionsRef: { current: {} },
     reconnectCount: { current: 0 },
+    lastMessageTime: { current: Date.now() },
     reconnect: { current: noop },
 };
 
@@ -24,6 +25,7 @@ const subscriber2: Subscriber = {
     setReadyState: noop,
     optionsRef: { current: {} },
     reconnectCount: { current: 0 },
+    lastMessageTime: { current: Date.now() },
     reconnect: { current: noop },
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,6 +56,7 @@ export type Subscriber<T = WebSocketEventMap['message']> = {
   setReadyState: (readyState: ReadyState) => void,
   optionsRef: MutableRefObject<Options>,
   reconnectCount: MutableRefObject<number>,
+  lastMessageTime: MutableRefObject<number>,
   reconnect: MutableRefObject<() => void>,
 }
 

--- a/src/lib/use-websocket.test.ts
+++ b/src/lib/use-websocket.test.ts
@@ -8,7 +8,7 @@ import { parseSocketIOUrl } from './socket-io';
 let server: WS;
 const URL = 'ws://localhost:1234';
 const SOCKET_IO_URL = parseSocketIOUrl(URL);
-const noop = () => {};
+const noop = () => { };
 const DEFAULT_OPTIONS: Options = {};
 let options: Options;
 const sleep = (duration: number): Promise<void> => new Promise(resolve => setTimeout(() => resolve(), duration));
@@ -224,9 +224,9 @@ test('sendJsonMessage allows component to pass a json object which is serialized
     result,
   } = renderHook(() => useWebSocket(URL, options))
   await server.connected;
-  result.current.sendJsonMessage({ name: 'Bob'  });
+  result.current.sendJsonMessage({ name: 'Bob' });
 
-  await expect(server).toReceiveMessage(JSON.stringify({ name: 'Bob'  }));
+  await expect(server).toReceiveMessage(JSON.stringify({ name: 'Bob' }));
 })
 
 test('getWebSocket returns the underlying websocket if unshared', async () => {
@@ -261,7 +261,7 @@ test('websocket is closed when the component unmounts', async () => {
   } = renderHook(() => useWebSocket(URL, options))
   await server.connected;
   const ws = result.current.getWebSocket();
-  
+
   unmount();
   expect(ws?.readyState).toBe(ReadyState.CLOSING);
   await sleep(500);
@@ -284,16 +284,16 @@ test('shared websockets receive updates as if unshared', async () => {
   } = renderHook(() => useWebSocket(URL, options))
   await server.connected;
 
-  
+
   server.send('Hello all');
-  
+
   expect(component1.current.lastMessage?.data).toBe('Hello all');
   expect(component2.current.lastMessage?.data).toBe('Hello all');
   expect(component3.current.lastMessage?.data).toBe('Hello all');
 })
 
 test('shared websockets each have callbacks invoked as if unshared', async () => {
-  const component1OnClose = jest.fn(() => {});
+  const component1OnClose = jest.fn(() => { });
   renderHook(() => useWebSocket(URL, {
     ...options,
     onClose: component1OnClose,
@@ -301,7 +301,7 @@ test('shared websockets each have callbacks invoked as if unshared', async () =>
 
   await server.connected;
 
-  const component2OnClose = jest.fn(() => {});
+  const component2OnClose = jest.fn(() => { });
   renderHook(() => useWebSocket(URL, {
     ...options,
     onClose: component2OnClose,
@@ -309,7 +309,7 @@ test('shared websockets each have callbacks invoked as if unshared', async () =>
 
   await server.connected;
 
-  const component3OnClose = jest.fn(() => {}); 
+  const component3OnClose = jest.fn(() => { });
   renderHook(() => useWebSocket(URL, {
     ...options,
     onClose: component3OnClose,
@@ -372,7 +372,7 @@ test('Options#protocols pass the value on to the instantiated WebSocket', async 
 
 test('Options#share subscribes multiple components to a single WebSocket, so long as the URL is the same', async () => {
   options.share = true;
-  
+
   const onConnectionFn = jest.fn();
   server.on('connection', onConnectionFn);
 
@@ -428,7 +428,7 @@ test('Options#onMessage is called with the MessageEvent when the websocket recei
 
   renderHook(() => useWebSocket(URL, options));
   await server.connected;
-  
+
   server.send('Hello');
 
   await waitFor(() => {
@@ -443,7 +443,7 @@ test('Options#onError is called when the websocket connection errors out', async
 
   renderHook(() => useWebSocket(URL, options));
   await server.connected;
-  
+
   server.error();
 
   await waitFor(() => {
@@ -475,7 +475,7 @@ test('Options#onReconnectStop is called when the websocket exceeds maximum recon
   options.shouldReconnect = () => true;
   options.reconnectAttempts = 3;
   options.reconnectInterval = 500; //Default interval is too long for tests
-  const onReconnectStopFn = jest.fn((numAttempts: number) => {});
+  const onReconnectStopFn = jest.fn((numAttempts: number) => { });
   options.onReconnectStop = onReconnectStopFn;
 
   renderHook(() => useWebSocket(URL, options));
@@ -484,7 +484,7 @@ test('Options#onReconnectStop is called when the websocket exceeds maximum recon
   expect(onReconnectStopFn).not.toHaveBeenCalled();
 
   await sleep(2000);
-  
+
   expect(onReconnectStopFn).toHaveBeenCalled();
   expect(onReconnectStopFn.mock.calls[0][0]).toBe(3);
 });
@@ -583,7 +583,7 @@ test.each([false, true])('Options#heartbeat, if provided, do not close websocket
     interval: 500,
   };
   options.share = shareOption;
-  
+
   const {
     result,
   } = renderHook(() => useWebSocket(URL, options));
@@ -591,7 +591,7 @@ test.each([false, true])('Options#heartbeat, if provided, do not close websocket
   if (shareOption) {
     renderHook(() => useWebSocket(URL, options));
   }
-  
+
   await server.connected;
   server.send('ping')
   await sleep(500);
@@ -620,7 +620,7 @@ test.each([false, true])('Options#heartbeat, if provided, lastMessage is updated
   if (shareOption) {
     renderHook(() => useWebSocket(URL, options));
   }
-  
+
   await server.connected;
   server.send('pong');
   expect(result.current.lastMessage?.data).toBe(undefined);


### PR DESCRIPTION
 - Use one timer instead of two
 - Do not re-initialise timer when new message received
 - Start heartbeat when WS connection established
 - Store epoch time when last message was received, only send heartbeat messages when there is no traffic
 - Update tests to reflect changes