### PR TITLE
Targets esm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { useWebSocket as default } from './lib/use-websocket';
+import { useWebSocket } from './lib/use-websocket';
+export default useWebSocket;
 
 export { SendMessage, Options } from './lib/types';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,21 @@
 {
   "compilerOptions": {
-      "outDir": "./dist/",
-      "sourceMap": true,
-      "module": "commonjs",
-      "esModuleInterop": true,
-      "target": "es5",
-      "jsx": "react",
-      "skipLibCheck": true,
-      "lib": ["es2017", "dom"],
-      "types" : ["node", "websocket", "jest"],
-      "strict": true,
-      "declaration": true,
-      "baseUrl": ".",
-      "paths": {
-        "@lib/*": [
-            "src/lib/*"
-        ]
+    "outDir": "./dist/",
+    "sourceMap": true,
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "target": "ESNext",
+    "jsx": "react",
+    "skipLibCheck": true,
+    "lib": ["es2017", "dom"],
+    "types": ["node", "websocket", "jest"],
+    "strict": true,
+    "declaration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@lib/*": ["src/lib/*"]
     }
   },
-  "files": [
-    "./src/index.ts"
-  ],
-  "include": [
-    "src/*"
-  ]
+  "files": ["./src/index.ts"],
+  "include": ["src/*"]
 }


### PR DESCRIPTION
The js ecosystem has shifted to supporting esm by default. These are the small changes we need to make that transition! If instead we are wanting to target both cjs and esm happy to make a pr for that, it will require some additional changes! Thanks for this awesome lib ❤️ 

Fixes #242 