### PR TITLE
fixes #250 Fix reconnect after unsuccessful heartbeat

### DIFF
--- a/src/lib/attach-listener.ts
+++ b/src/lib/attach-listener.ts
@@ -60,6 +60,7 @@ const bindOpenHandler = (
         typeof optionsRef.current.heartbeat === "boolean"
           ? undefined
           : optionsRef.current.heartbeat;
+      lastMessageTime.current = Date.now();
       heartbeat(webSocketInstance, lastMessageTime, heartbeatOptions);
     }
 

--- a/src/lib/attach-shared-listeners.ts
+++ b/src/lib/attach-shared-listeners.ts
@@ -17,15 +17,15 @@ const bindMessageHandler = (
         subscriber.optionsRef.current.onMessage(message);
       }
 
+      if (typeof subscriber?.lastMessageTime?.current === 'number') {
+        subscriber.lastMessageTime.current = Date.now();
+      }
+
       if (
         typeof subscriber.optionsRef.current.filter === 'function' &&
         subscriber.optionsRef.current.filter(message) !== true
       ) {
         return;
-      }
-
-      if (typeof subscriber?.lastMessageTime?.current === 'number') {
-        subscriber.lastMessageTime.current = Date.now();
       }
 
       if (
@@ -57,6 +57,7 @@ const bindOpenHandler = (
       let onMessageCb: () => void;
 
       if (heartbeatOptions && webSocketInstance instanceof WebSocket) {
+        subscriber.lastMessageTime.current = Date.now();
         heartbeat(webSocketInstance, subscriber.lastMessageTime, typeof heartbeatOptions === 'boolean' ? undefined : heartbeatOptions,);
       }
     });


### PR DESCRIPTION
 - Set lastMessageTime on WS open event
 - Add tests for shared and non-shared websocket modes