### PR TITLE
Add null to lastJsonMessage type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,7 +64,7 @@ export type WebSocketHook<T = unknown, P = WebSocketEventMap['message'] | null> 
   sendMessage: SendMessage,
   sendJsonMessage: SendJsonMessage,
   lastMessage: P,
-  lastJsonMessage: T,
+  lastJsonMessage: T | null,
   readyState: ReadyState,
   getWebSocket: () => (WebSocketLike | null),
 }


### PR DESCRIPTION
The user has no control over the fact that on first render, `lastJsonMessage` will be `null`. And it always is like that (I suspect. Without digging through the code, I don't imagine there's a scenario where the socket is established and sets the value quickly enough for it not to be?).

And so I would argue that the user should have no option of *not* including `null`. They might also wrongly assume that `undefined` is used.