### PR TITLE
Add tests for disconnect using connect argument

### DIFF
--- a/src/lib/use-websocket.test.ts
+++ b/src/lib/use-websocket.test.ts
@@ -31,6 +31,11 @@ test('useWebsocket should work with just a url provided', () => {
 })
 
 test('readyState changes across readyState transitions', async () => {
+  const onCloseMock = jest.fn();
+  const onConnectionMock = jest.fn();
+  server.on("close", onCloseMock);
+  server.on("connection", onConnectionMock);
+
   const {
     result,
     rerender,
@@ -44,14 +49,17 @@ test('readyState changes across readyState transitions', async () => {
   expect(result.current.readyState).toEqual(ReadyState.CONNECTING);
   await server.connected;
   expect(result.current.readyState).toEqual(ReadyState.OPEN);
+  expect(onConnectionMock).toHaveBeenCalledTimes(1);
 
   rerender({
     initialValue: false
   });
 
   await server.closed;
+  expect(onCloseMock).toHaveBeenCalledTimes(1);
 
   expect(result.current.readyState).toEqual(ReadyState.CLOSED);
+
 
   rerender({ initialValue: true });
 
@@ -61,8 +69,11 @@ test('readyState changes across readyState transitions', async () => {
   });
 
   await server.connected;
+  expect(onConnectionMock).toHaveBeenCalledTimes(2);
 
   server.close();
+  await server.closed;
+  expect(onCloseMock).toHaveBeenCalledTimes(2);
   expect(result.current.readyState).toEqual(ReadyState.CLOSED);
 })
 

--- a/src/lib/use-websocket.test.ts
+++ b/src/lib/use-websocket.test.ts
@@ -45,8 +45,25 @@ test('readyState changes across readyState transitions', async () => {
   await server.connected;
   expect(result.current.readyState).toEqual(ReadyState.OPEN);
 
+  rerender({
+    initialValue: false
+  });
+
+  await server.closed;
+
+  expect(result.current.readyState).toEqual(ReadyState.CLOSED);
+
+  rerender({ initialValue: true });
+
+  // for some reason, the connecting state is too fast here to show up, just wait for OPEN
+  await waitFor(() => {
+    expect(result.current.readyState).toEqual(ReadyState.OPEN);
+  });
+
+  await server.connected;
+
   server.close();
-  await expect(result.current.readyState).toEqual(ReadyState.CLOSED);
+  expect(result.current.readyState).toEqual(ReadyState.CLOSED);
 })
 
 test('a function-promise based url works the same as a string-based url', async () => {


### PR DESCRIPTION
In the README, it states that since version 2.0.0, you can disconnect from the socket using the `connect` (third) argument of the hook, but there doesn't seem to be a test for it.

> Components can close/unsubscribe from a WebSocket by passing false as the third parameter. This provides a more explicit solution than the previous method of setting the socketUrl to null. Both methods work and are supported usage.


This PR adds a test so nobody else has to investigate whether it's the library's code or their own which isn't working 😅 (spoiler it was my own code).

A few points of note:
- The `ReadyState.CONNECTING` on the reconnect is happening, but in the tests it happens to fast to read the state out and assert on it.
- Ideally the `WS` mock from `jest-mock-websocket` could tell us how many connections there are (is that just 0 or 1 ?), but alas it cannot. So using some mocks of the events to validate that we have connected and disconnected the right amount of times.

